### PR TITLE
Add a `:root` image build that runs as `root`.

### DIFF
--- a/.apko-root.yaml
+++ b/.apko-root.yaml
@@ -1,0 +1,21 @@
+contents:
+  repositories:
+    - https://dl-cdn.alpinelinux.org/alpine/edge/main
+    - https://dl-cdn.alpinelinux.org/alpine/edge/community
+  packages:
+    - alpine-baselayout-data
+    - ca-certificates-bundle
+    - git
+    - git-lfs
+    - openssh-client
+
+entrypoint:
+  command: /usr/bin/git
+
+accounts:
+  groups:
+    - groupname: nonroot
+      gid: 65532
+  users:
+    - username: nonroot
+      uid: 65532

--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -29,6 +29,11 @@ jobs:
         config: .apko.yaml
         tag: template:${{ steps.snapshot-date.outputs.date }}
 
+    - uses: distroless/actions/apko-build@main
+      with:
+        config: .apko-root.yaml
+        tag: template:root-${{ steps.snapshot-date.outputs.date }}
+
     - uses: actions/upload-artifact@v3
       with:
         name: template.tar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,13 @@ jobs:
       with:
         config: .apko.yaml
         base-tag: ghcr.io/${{ github.repository }}
+        target-tag: latest
+
+    - uses: distroless/actions/apko-snapshot@main
+      with:
+        config: .apko.yaml
+        base-tag: ghcr.io/${{ github.repository }}
+        target-tag: root
 
     # Post to slack when things fail.
     - if: ${{ failure() }}


### PR DESCRIPTION
This is identical to the `nonroot` image, and even adds the user, but doesn't actually run as that user by default.

Needs: https://github.com/distroless/actions/pull/8 or it will fail.